### PR TITLE
perf: remove semver check

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,12 +38,11 @@
     "chokidar": "^3.5.3",
     "memfs": "^4.14.0",
     "minimatch": "^9.0.5",
-    "picocolors": "^1.1.1",
-    "semver": "^7.3.5"
+    "picocolors": "^1.1.1"
   },
   "peerDependencies": {
     "@rspack/core": "^1.0.0",
-    "typescript": ">3.6.0"
+    "typescript": ">=3.8.0"
   },
   "devDependencies": {
     "@jest/console": "^27.0.0",
@@ -54,7 +53,6 @@
     "@types/mock-fs": "^4.13.1",
     "@types/node": "^16.4.13",
     "@types/rimraf": "^3.0.2",
-    "@types/semver": "^7.3.9",
     "cross-env": "^7.0.3",
     "husky": "^7.0.4",
     "jest": "^27.4.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
-      semver:
-        specifier: ^7.3.5
-        version: 7.6.3
     devDependencies:
       '@jest/console':
         specifier: ^27.0.0
@@ -54,9 +51,6 @@ importers:
       '@types/rimraf':
         specifier: ^3.0.2
         version: 3.0.2
-      '@types/semver':
-        specifier: ^7.3.9
-        version: 7.5.8
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1147,9 +1141,6 @@ packages:
 
   '@types/rimraf@3.0.2':
     resolution: {integrity: sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==}
-
-  '@types/semver@7.5.8':
-    resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
 
   '@types/send@0.17.4':
     resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
@@ -4877,8 +4868,6 @@ snapshots:
     dependencies:
       '@types/glob': 8.1.0
       '@types/node': 16.18.119
-
-  '@types/semver@7.5.8': {}
 
   '@types/send@0.17.4':
     dependencies:

--- a/src/typescript/type-script-support.ts
+++ b/src/typescript/type-script-support.ts
@@ -1,7 +1,5 @@
 import os from 'os';
-
 import fs from 'node:fs';
-import * as semver from 'semver';
 
 import type { TypeScriptWorkerConfig } from './type-script-worker-config';
 
@@ -18,23 +16,6 @@ function assertTypeScriptSupport(config: TypeScriptWorkerConfig) {
   if (!typescriptVersion) {
     throw new Error(
       'When you use TsCheckerRspackPlugin with typescript reporter enabled, you must install `typescript` package.'
-    );
-  }
-
-  if (semver.lt(typescriptVersion, '3.6.0')) {
-    throw new Error(
-      [
-        `TsCheckerRspackPlugin cannot use the current typescript version of ${typescriptVersion}.`,
-        'The minimum required version is 3.6.0.',
-      ].join(os.EOL)
-    );
-  }
-  if (config.build && semver.lt(typescriptVersion, '3.8.0')) {
-    throw new Error(
-      [
-        `TsCheckerRspackPlugin doesn't support build option for the current typescript version of ${typescriptVersion}.`,
-        'The minimum required version is 3.8.0.',
-      ].join(os.EOL)
     );
   }
 

--- a/test/unit/typescript/type-script-support.spec.ts
+++ b/test/unit/typescript/type-script-support.spec.ts
@@ -37,28 +37,6 @@ describe('typescript/type-script-support', () => {
     );
   });
 
-  it('throws error if typescript version is lower then 3.6.0', async () => {
-    jest.setMock('typescript', { version: '3.5.9' });
-
-    const { assertTypeScriptSupport } = await import('src/typescript/type-script-support');
-
-    expect(() => assertTypeScriptSupport(configuration)).toThrowError(
-      [
-        `TsCheckerRspackPlugin cannot use the current typescript version of 3.5.9.`,
-        'The minimum required version is 3.6.0.',
-      ].join(os.EOL)
-    );
-  });
-
-  it("doesn't throw error if typescript version is greater or equal 3.6.0", async () => {
-    jest.setMock('typescript', { version: '3.6.0' });
-    jest.setMock('node:fs', { existsSync: () => true });
-
-    const { assertTypeScriptSupport } = await import('src/typescript/type-script-support');
-
-    expect(() => assertTypeScriptSupport(configuration)).not.toThrowError();
-  });
-
   it('throws error if there is no tsconfig.json file', async () => {
     jest.setMock('typescript', { version: '3.8.0' });
     jest.setMock('node:fs', { existsSync: () => false });


### PR DESCRIPTION
This pull request includes several changes to the `package.json`, `pnpm-lock.yaml`, and `typescript` support files, primarily focused on removing the `semver` dependency and updating TypeScript version requirements.

Motivation: TypeScript <= 3.6 is rarely used now.