### PR TITLE
fix: handle undefined path in `getModifiedTime`

### DIFF
--- a/src/typescript/worker/lib/host/watch-solution-builder-host.ts
+++ b/src/typescript/worker/lib/host/watch-solution-builder-host.ts
@@ -45,7 +45,7 @@ export function createWatchSolutionBuilderHost<TProgram extends ts.BuilderProgra
     writeFile(path: string, data: string): void {
       system.writeFile(path, data);
     },
-    getModifiedTime(fileName: string): Date | undefined {
+    getModifiedTime(fileName: string | undefined): Date | undefined {
       return system.getModifiedTime(fileName);
     },
     setModifiedTime(fileName: string, date: Date): void {

--- a/src/typescript/worker/lib/system.ts
+++ b/src/typescript/worker/lib/system.ts
@@ -32,7 +32,7 @@ export interface ControlledTypeScriptSystem extends ts.System {
     recursive?: boolean,
     options?: ts.WatchOptions
   ): ts.FileWatcher;
-  getModifiedTime(path: string): Date | undefined;
+  getModifiedTime(path: string | undefined): Date | undefined;
   setModifiedTime(path: string, time: Date): void;
   deleteFile(path: string): void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -113,9 +113,12 @@ export const system: ControlledTypeScriptSystem = {
       )
       .map((dirent) => dirent.name);
   },
-  getModifiedTime(path: string): Date | undefined {
-    const stats = getReadFileSystem(path).readStats(path);
+  getModifiedTime(path: string | undefined): Date | undefined {
+    if (path === undefined) {
+      return undefined;
+    }
 
+    const stats = getReadFileSystem(path).readStats(path);
     if (stats) {
       return stats.mtime;
     }


### PR DESCRIPTION
resolve https://github.com/rspack-contrib/ts-checker-rspack-plugin/issues/14