### PR TITLE
test: add cases for createIsIgnored function

### DIFF
--- a/src/watch/inclusive-node-watch-file-system.ts
+++ b/src/watch/inclusive-node-watch-file-system.ts
@@ -14,7 +14,7 @@ import type { WatchFileSystem } from './watch-file-system';
 
 const BUILTIN_IGNORED_DIRS = ['.git'];
 
-function createIsIgnored(
+export function createIsIgnored(
   ignored: string | RegExp | (string | RegExp)[] | undefined,
   excluded: string[]
 ): (path: string) => boolean {

--- a/test/unit/watch/inclusive-node-watch-file-system.test.ts
+++ b/test/unit/watch/inclusive-node-watch-file-system.test.ts
@@ -1,0 +1,32 @@
+import { createIsIgnored } from '../../../src/watch/inclusive-node-watch-file-system';
+
+describe('createIsIgnored', () => {
+  const gitPath = '/path/to/.git/foo';
+  const nodeModulesPath = '/path/to/node_modules/foo/dist/index.js';
+  const distModulePath = '/path/to/dist/foo.js';
+  const srcModulePath = '/path/to/src/foo.ts';
+
+  it('should allow to passing RegExp to the first argument', () => {
+    const isIgnored = createIsIgnored([/[\\/](?:\.git|node_modules)[\\/]/], []);
+    expect(isIgnored(gitPath)).toBe(true);
+    expect(isIgnored(nodeModulesPath)).toBe(true);
+    expect(isIgnored(distModulePath)).toBe(false);
+    expect(isIgnored(srcModulePath)).toBe(false);
+  });
+
+  it('should allow to passing string path to the first argument', () => {
+    const isIgnored = createIsIgnored(['/path/to/.git'], []);
+    expect(isIgnored(gitPath)).toBe(true);
+    expect(isIgnored(nodeModulesPath)).toBe(false);
+    expect(isIgnored(distModulePath)).toBe(false);
+    expect(isIgnored(srcModulePath)).toBe(false);
+  });
+
+  it('should allow to passing string path to the second argument', () => {
+    const isIgnored = createIsIgnored([], ['/path/to/dist']);
+    expect(isIgnored(gitPath)).toBe(true);
+    expect(isIgnored(nodeModulesPath)).toBe(false);
+    expect(isIgnored(distModulePath)).toBe(true);
+    expect(isIgnored(srcModulePath)).toBe(false);
+  });
+});


### PR DESCRIPTION
Added a test suite for the `createIsIgnored` function. The tests verify its behavior with different combinations of string paths and regular expressions as arguments, ensuring correctness for various use cases.