### PR TITLE
fix: glob patterns in tsconfig.json `exclude` option does not work

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@babel/code-frame": "^7.16.7",
     "@rspack/lite-tapable": "^1.0.0",
     "chokidar": "^3.5.3",
+    "is-glob": "^4.0.3",
     "memfs": "^4.14.0",
     "minimatch": "^9.0.5",
     "picocolors": "^1.1.1"
@@ -53,6 +54,7 @@
     "@jest/console": "^27.0.0",
     "@rspack/core": "^1.1.3",
     "@types/babel__code-frame": "^7.0.3",
+    "@types/is-glob": "^4.0.4",
     "@types/jest": "^27.4.0",
     "@types/mock-fs": "^4.13.1",
     "@types/node": "^16.4.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       chokidar:
         specifier: ^3.5.3
         version: 3.6.0
+      is-glob:
+        specifier: ^4.0.3
+        version: 4.0.3
       memfs:
         specifier: ^4.14.0
         version: 4.14.0
@@ -36,6 +39,9 @@ importers:
       '@types/babel__code-frame':
         specifier: ^7.0.3
         version: 7.0.6
+      '@types/is-glob':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/jest':
         specifier: ^27.4.0
         version: 27.5.2
@@ -1042,21 +1048,25 @@ packages:
     resolution: {integrity: sha512-MpOrO1oppxAm8J1ztNz6G5DG/oL9ZLHmIz9vYNV6PKnk+MPhCXqfhFmQ2hZm5VIVKuOobfYEJiDUqKg2MLg8gA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rspack/binding-linux-arm64-musl@1.1.3':
     resolution: {integrity: sha512-PnUDC1JxT6a5hJW0hhJ9ubWk3R+nk7eLXyNaORHyQH4k8o89Zm5GYoKnDgO4eRy41NB9/aBJQJRGSRn0iAsZgw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rspack/binding-linux-x64-gnu@1.1.3':
     resolution: {integrity: sha512-+6JgyKXOp2QrHzlru95mge70tDkYlaY4NNE9xyrdj6PgTnM9cVPx4sLVhHC9+tWXaTFnccfEe9Tt6LjKnjHGaA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rspack/binding-linux-x64-musl@1.1.3':
     resolution: {integrity: sha512-X0TJTVL1Roqq/tvN26QO4u62x2xp5tE0dlhwhbeCHrBdgBzc+PHvcv/8lclRcq6lDPzceAgcnNX/+RbWg0DzKg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rspack/binding-win32-arm64-msvc@1.1.3':
     resolution: {integrity: sha512-Lvpp5Q30YiPNkuOFPawp2al2CTWElPeG3X0E9LFIfPdVkLc/e2nkf5a6zSYtnbD2oaskzQIYN/k27fWqWWcVHA==}
@@ -1166,6 +1176,9 @@ packages:
 
   '@types/http-proxy@1.17.15':
     resolution: {integrity: sha512-25g5atgiVNTIv0LBDTg1H74Hvayx0ajtJPLLcYE3whFv75J0pWNtOBzaXJQgDTmrX1bx5U9YC2w/n65BN1HwRQ==}
+
+  '@types/is-glob@4.0.4':
+    resolution: {integrity: sha512-3mFBtIPQ0TQetKRDe94g8YrxJZxdMillMGegyv6zRBXvq4peRRhf2wLZ/Dl53emtTsC29dQQBwYvovS20yXpiQ==}
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -5004,6 +5017,8 @@ snapshots:
   '@types/http-proxy@1.17.15':
     dependencies:
       '@types/node': 16.18.119
+
+  '@types/is-glob@4.0.4': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 

--- a/test/unit/watch/inclusive-node-watch-file-system.test.ts
+++ b/test/unit/watch/inclusive-node-watch-file-system.test.ts
@@ -23,10 +23,34 @@ describe('createIsIgnored', () => {
   });
 
   it('should allow to passing string path to the second argument', () => {
+    // exclude: ["dist"] in tsconfig.json
     const isIgnored = createIsIgnored([], ['/path/to/dist']);
     expect(isIgnored(gitPath)).toBe(true);
     expect(isIgnored(nodeModulesPath)).toBe(false);
     expect(isIgnored(distModulePath)).toBe(true);
     expect(isIgnored(srcModulePath)).toBe(false);
+  });
+
+  it('should allow to passing glob path to the second argument', () => {
+    // exclude: ["dist/**"] in tsconfig.json
+    const isIgnored1 = createIsIgnored([], ['/path/to/dist/**']);
+    expect(isIgnored1(gitPath)).toBe(true);
+    expect(isIgnored1(nodeModulesPath)).toBe(false);
+    expect(isIgnored1(distModulePath)).toBe(true);
+    expect(isIgnored1(srcModulePath)).toBe(false);
+
+    // exclude: ["**/dist/**"] in tsconfig.json
+    const isIgnored2 = createIsIgnored([], ['/path/to/**/dist/**']);
+    expect(isIgnored2(gitPath)).toBe(true);
+    expect(isIgnored2(nodeModulesPath)).toBe(true);
+    expect(isIgnored2(distModulePath)).toBe(true);
+    expect(isIgnored2(srcModulePath)).toBe(false);
+
+    // exclude: ["**/dist/*"] in tsconfig.json
+    const isIgnored3 = createIsIgnored([], ['/path/to/**/dist/*']);
+    expect(isIgnored3(gitPath)).toBe(true);
+    expect(isIgnored3(nodeModulesPath)).toBe(true);
+    expect(isIgnored3(distModulePath)).toBe(true);
+    expect(isIgnored3(srcModulePath)).toBe(false);
   });
 });


### PR DESCRIPTION
Fix glob patterns in tsconfig.json `exclude` option does not work.

For example:

- `exclude: ["dist/**"]` in tsconfig.json
- `exclude: ["**/dist/*"]` in tsconfig.json
- `exclude: ["**/dist/**"]` in tsconfig.json

Ref: https://github.com/microsoft/TypeScript/wiki/Performance#misconfigured-include-and-exclude