### PR TITLE
fix: append star to improve ignore patterns

### DIFF
--- a/src/watch/inclusive-node-watch-file-system.ts
+++ b/src/watch/inclusive-node-watch-file-system.ts
@@ -1,4 +1,4 @@
-import { extname } from 'path';
+import path, { extname } from 'path';
 
 import type { FSWatcher } from 'chokidar';
 import chokidar from 'chokidar';
@@ -21,10 +21,17 @@ export function createIsIgnored(
 ): (path: string) => boolean {
   const ignoredPatterns = ignored ? (Array.isArray(ignored) ? ignored : [ignored]) : [];
 
-  const filteredExcluded = excluded.filter((path) => {
+  const filteredExcluded = excluded.filter((pattern) => {
     // Use `minimatch` to check if the path is a glob pattern.
-    if (isGlob(path)) {
-      ignoredPatterns.push(path);
+    if (isGlob(pattern)) {
+      // Append `/**` to the pattern to align minimatch's behavior
+      // with the `exclude` option in tsconfig.json.
+      const shouldAppendStar = pattern.includes('**') && !pattern.endsWith('*');
+      if (shouldAppendStar) {
+        ignoredPatterns.push(pattern.endsWith('/') ? `${pattern}**` : `${pattern}/**`);
+      } else {
+        ignoredPatterns.push(pattern);
+      }
       return false;
     }
     return true;

--- a/test/unit/watch/inclusive-node-watch-file-system.test.ts
+++ b/test/unit/watch/inclusive-node-watch-file-system.test.ts
@@ -6,6 +6,14 @@ describe('createIsIgnored', () => {
   const distModulePath = '/path/to/dist/foo.js';
   const srcModulePath = '/path/to/src/foo.ts';
 
+  it('should handle built-in ignored directories', () => {
+    const customPath = '/path/without/git/or/node_modules';
+    const isIgnored = createIsIgnored([], []);
+    expect(isIgnored(gitPath)).toBe(true);
+    expect(isIgnored(customPath)).toBe(false);
+    expect(isIgnored('/path/to/.github/foo')).toBe(false);
+  });
+
   it('should allow to passing RegExp to the first argument', () => {
     const isIgnored = createIsIgnored([/[\\/](?:\.git|node_modules)[\\/]/], []);
     expect(isIgnored(gitPath)).toBe(true);
@@ -52,5 +60,34 @@ describe('createIsIgnored', () => {
     expect(isIgnored3(nodeModulesPath)).toBe(true);
     expect(isIgnored3(distModulePath)).toBe(true);
     expect(isIgnored3(srcModulePath)).toBe(false);
+
+    // exclude: ["**/dist"] in tsconfig.json
+    const isIgnored4 = createIsIgnored([], ['/path/to/**/dist']);
+    expect(isIgnored4(gitPath)).toBe(true);
+    expect(isIgnored4(nodeModulesPath)).toBe(true);
+    expect(isIgnored4(distModulePath)).toBe(true);
+    expect(isIgnored4(srcModulePath)).toBe(false);
+
+    // exclude: ["**/dist/"] in tsconfig.json
+    const isIgnored5 = createIsIgnored([], ['/path/to/**/dist/']);
+    expect(isIgnored5(gitPath)).toBe(true);
+    expect(isIgnored5(nodeModulesPath)).toBe(true);
+    expect(isIgnored5(distModulePath)).toBe(true);
+    expect(isIgnored5(srcModulePath)).toBe(false);
+
+    // exclude: ["dist/**/*"] in tsconfig.json
+    const isIgnored6 = createIsIgnored([], ['/path/to/dist/**/*']);
+    expect(isIgnored6(gitPath)).toBe(true);
+    expect(isIgnored6(nodeModulesPath)).toBe(false);
+    expect(isIgnored6(distModulePath)).toBe(true);
+    expect(isIgnored6(srcModulePath)).toBe(false);
+  });
+
+  it('should combine multiple ignore patterns', () => {
+    const isIgnored = createIsIgnored([/[\\/]node_modules[\\/]/], ['/path/to/dist']);
+    expect(isIgnored(gitPath)).toBe(true);
+    expect(isIgnored(nodeModulesPath)).toBe(true);
+    expect(isIgnored(distModulePath)).toBe(true);
+    expect(isIgnored(srcModulePath)).toBe(false);
   });
 });


### PR DESCRIPTION
Append `/**` to the pattern to align minimatch's behavior with the `exclude` option in tsconfig.json.

See the test cases for more details.