### PR TITLE
fix: ignoredPatterns affect option.ignored referrence, cause watchpack error

### DIFF
--- a/src/watch/inclusive-node-watch-file-system.ts
+++ b/src/watch/inclusive-node-watch-file-system.ts
@@ -19,7 +19,7 @@ export function createIsIgnored(
   ignored: string | RegExp | (string | RegExp)[] | undefined,
   excluded: string[]
 ): (path: string) => boolean {
-  const ignoredPatterns = ignored ? (Array.isArray(ignored) ? ignored : [ignored]) : [];
+  const ignoredPatterns = ignored ? (Array.isArray(ignored) ? [...ignored] : [ignored]) : [];
 
   const filteredExcluded = excluded.filter((pattern) => {
     // Use `minimatch` to check if the path is a glob pattern.


### PR DESCRIPTION
This PR modify the logic so that ignoredPatterns does not affect the ignored reference.

> For addition, watchpack use `glob-to-regexp` to convert glob to regexp, it will replace `**` with `([^/]*)`. So `\\**` will be process to `\([^/]*)`, which cause `(` mismatch. 